### PR TITLE
Exclude Relative Path

### DIFF
--- a/app/app.go
+++ b/app/app.go
@@ -71,9 +71,8 @@ func (c *closeWrapper) Close() (err error) {
 func appFiles(path string, excludes []string) ([]string, error) {
 	var files []string
 	err := appfiles.ApplicationFiles{}.WalkAppFiles(path, func(relpath, _ string) error {
-		filename := filepath.Base(relpath)
 		for _, excludePattern := range excludes {
-			if regexp.MustCompile(excludePattern).MatchString(filename) {
+			if regexp.MustCompile(excludePattern).MatchString(relpath) {
 				return nil
 			}
 		}


### PR DESCRIPTION
When building the tar, this uses the relative path in the source directory vs just the filename.